### PR TITLE
Update to work on Gnome Shell 3.22

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,10 +2,11 @@
     "shell-version": [
         "3.10",
         "3.12",
-	      "3.14",
-	      "3.16",
-	      "3.18",
-	      "3.20"
+	"3.14",
+	"3.16",
+	"3.18",
+	"3.20",
+	"3.22"
     ],
     "uuid": "audio-switcher@AndresCidoncha",
     "name": "Audio Switcher",


### PR DESCRIPTION
I've just tested with only that change in the `metadata.json` file and it seems to work fine in my system (ArchLinux).
