### PR TITLE
GNOME shell 3.24 compatibility fixes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -158,9 +158,9 @@ function enable() {
 	volMen.addMenuItem(audioOutputSubMenu, i+1);
 
 	//Try to add the input-switcher right below the input slider...
-	let volMen = Main.panel.statusArea.aggregateMenu._volume._volumeMenu;
-	let items = volMen._getMenuItems();
-	let i = 0;
+	volMen = Main.panel.statusArea.aggregateMenu._volume._volumeMenu;
+	items = volMen._getMenuItems();
+	i = 0;
 	while (i < items.length)
 		if (items[i] === volMen._input.item)
 			break;

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
 	"3.16",
 	"3.18",
 	"3.20",
-	"3.22"
+	"3.22",
+	"3.24"
     ],
     "uuid": "audio-switcher@AndresCidoncha",
     "name": "Audio Switcher",


### PR DESCRIPTION
GNOME Shell 3.24 now uses mozjs38 (SpiderMonkey 38) which has stricter syntax rules.
https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey

In particular, repeated declarations of the same variable in a single code block will result in errors like this:

```
Mar 29 14:32:01 apollon.suse.de gnome-shell[10383]: JS ERROR: Exception in callback for signal: extension-found: TypeError: redeclaration of let v
                                                    initExtension@resource:///org/gnome/shell/ui/extensionSystem.js:221:5
                                                    loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:168:18
                                                    _loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:304:9
                                                    _emit@resource:///org/gnome/gjs/modules/signals.js:126:27
                                                    ExtensionFinder<._loadExtension@resource:///org/gnome/shell/misc/extensionUtils.js:184:9
                                                    wrapper@resource:///org/gnome/gjs/modules/lang.js:178:22
                                                    bind/<@resource:///org/gnome/gjs/modules/lang.js:95:16
                                                    collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:1
                                                    ExtensionFinder<.scanExtensions@resource:///org/gnome/shell/misc/extensionUtils.js:189:9
                                                    wrapper@resource:///org/gnome/gjs/modules/lang.js:178:22
                                                    _loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:306:5
                                                    enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:314:9
                                                    _sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:345:9
                                                    init@resource:///org/gnome/shell/ui/extensionSystem.js:353:5
                                                    _initializeUI@resource:///org/gnome/shell/ui/main.js:219:5
                                                    start@resource:///org/gnome/shell/ui/main.js:127:5
                                                    @<main>:1:31
```
