### PR TITLE
Fix TypeError on gnome-shell 3.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@
 ![The input menu](http://imgur.com/4jazC67.png)
 
 ## Compatibility
-  - Gnome Shell 3.10
-  - Gnome Shell 3.12
-  - Gnome Shell 3.14
-  - Gnome Shell 3.16
-  - Gnome Shell 3.18
-  - Gnome Shell 3.20
-  - Gnome Shell 3.24
   - Gnome Shell 3.26
+  - Gnome Shell 3.28
+  - Gnome Shell 3.30
+  - Gnome Shell 3.32
+
+
+For Gnome Shell < 3.26, use commit 434b12e1d4543e30d07e0fb6a80a1a4b36562897.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   - Gnome Shell 3.32
 
 
-For Gnome Shell < 3.26, use commit 434b12e1d4543e30d07e0fb6a80a1a4b36562897.
+For Gnome Shell < 3.26, use version 1.0.
 
 ## Installation
 
@@ -46,3 +46,4 @@ add support for the lastest versions of Gnome-shell.
 * [ChuckDaniels87](https://github.com/ChuckDaniels87)
 * [Martin Wilck](https://github.com/mwilck)
 * [Stefan Betz](https://github.com/encbladexp)
+* [Christoph Heiss](https://github.com/christoph-heiss)

--- a/extension.js
+++ b/extension.js
@@ -2,14 +2,11 @@ const Lang = imports.lang;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
 
-const AudioOutputSubMenu = new Lang.Class({
-	Name: 'AudioOutputSubMenu',
-	Extends: PopupMenu.PopupSubMenuMenuItem,
+class AudioOutputSubMenu extends PopupMenu.PopupSubMenuMenuItem {
+	constructor() {
+		super('Audio Output: Connecting...', true);
 
-	_init: function() {
 		this._control = Main.panel.statusArea.aggregateMenu._volume._control;
-
-		this.parent('Audio Output: Connecting...', true);
 
 		this._controlSignal = this._control.connect('default-sink-changed', Lang.bind(this, function() {
 			this._updateDefaultSink();
@@ -25,18 +22,18 @@ const AudioOutputSubMenu = new Lang.Class({
 		//Unless there is at least one item here, no 'open' will be emitted...
 		let item = new PopupMenu.PopupMenuItem('Connecting...');
 		this.menu.addMenuItem(item);
-	},
+	}
 
-	_updateDefaultSink: function () {
+	_updateDefaultSink() {
 		let defsink = this._control.get_default_sink();
 		//Unfortunately, Gvc neglects some pulse-devices, such as all "Monitor of ..."
 		if (defsink == null)
 			this.label.set_text("Other");
 		else
 			this.label.set_text(defsink.get_description());
-	},
+	}
 
-	_updateSinkList: function () {
+	_updateSinkList() {
 		this.menu.removeAll();
 
 		let defsink = this._control.get_default_sink();
@@ -59,22 +56,20 @@ const AudioOutputSubMenu = new Lang.Class({
 			item = new PopupMenu.PopupMenuItem("No more Devices");
 			this.menu.addMenuItem(item);
 		}
-	},
-
-	destroy: function() {
-		this._control.disconnect(this._controlSignal);
-		this.parent();
 	}
-});
 
-const AudioInputSubMenu = new Lang.Class({
-	Name: 'AudioInputSubMenu',
-	Extends: PopupMenu.PopupSubMenuMenuItem,
+	destroy() {
+		this._control.disconnect(this._controlSignal);
+		super.destroy();
+	}
+}
 
-	_init: function() {
+class AudioInputSubMenu extends PopupMenu.PopupSubMenuMenuItem {
+	constructor() {
+		super('Audio Input: Connecting...', true);
+
 		this._control = Main.panel.statusArea.aggregateMenu._volume._control;
 
-		this.parent('Audio Input: Connecting...', true);
 
 		this._controlSignal = this._control.connect('default-source-changed', Lang.bind(this, function() {
 			this._updateDefaultSource();
@@ -90,18 +85,18 @@ const AudioInputSubMenu = new Lang.Class({
 		//Unless there is at least one item here, no 'open' will be emitted...
 		let item = new PopupMenu.PopupMenuItem('Connecting...');
 		this.menu.addMenuItem(item);
-	},
+	}
 
-	_updateDefaultSource: function () {
+	_updateDefaultSource() {
 		let defsource = this._control.get_default_source();
 		//Unfortunately, Gvc neglects some pulse-devices, such as all "Monitor of ..."
 		if (defsource == null)
 			this.label.set_text("Other");
 		else
 			this.label.set_text(defsource.get_description());
-	},
+	}
 
-	_updateSourceList: function () {
+	_updateSourceList() {
 		this.menu.removeAll();
 
 		let defsource = this._control.get_default_source();
@@ -125,13 +120,13 @@ const AudioInputSubMenu = new Lang.Class({
 			item = new PopupMenu.PopupMenuItem("No more Devices");
 			this.menu.addMenuItem(item);
 		}
-	},
-
-	destroy: function() {
-		this._control.disconnect(this._controlSignal);
-		this.parent();
 	}
-});
+
+	destroy() {
+		this._control.disconnect(this._controlSignal);
+		super.destroy();
+	}
+}
 
 var audioOutputSubMenu = null;
 var audioInputSubMenu = null;

--- a/metadata.json
+++ b/metadata.json
@@ -1,14 +1,9 @@
 {
     "shell-version": [
-        "3.10",
-        "3.12",
-	"3.14",
-	"3.16",
-	"3.18",
-	"3.20",
-	"3.22",
-	"3.24",
-	"3.26"
+	"3.26",
+	"3.28",
+	"3.30",
+	"3.32"
     ],
     "uuid": "audio-switcher@AndresCidoncha",
     "name": "Audio Switcher",


### PR DESCRIPTION
Hi,

according to https://ptomato.wordpress.com/2017/04/28/gjs-whats-next/, ES6 classes are available since gnome-shell 3.26 and should be used instead of Lang.Class.
Support for Lang.Class was probably removed in 3.32 and thus broke this extension.

By the way: Thanks for this extension, really useful for me!

Fixes #9 