### PR TITLE
Fix extension error on Gnome 3.34

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,4 +1,3 @@
-const Lang = imports.lang;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
 const GObject = imports.gi.GObject;
@@ -11,16 +10,16 @@ const AudioOutputSubMenu = GObject.registerClass({
 
 		this._control = Main.panel.statusArea.aggregateMenu._volume._control;
 
-		this._controlSignal = this._control.connect('default-sink-changed', Lang.bind(this, function() {
+		this._controlSignal = this._control.connect('default-sink-changed', () => {
 			this._updateDefaultSink();
-		}));
+		});
 
 		this._updateDefaultSink();
 
-		this.menu.connect('open-state-changed', Lang.bind(this, function(menu, isOpen) {
+		this.menu.connect('open-state-changed', (menu, isOpen) => {
 			if (isOpen)
 				this._updateSinkList();
-		}));
+		});
 
 		//Unless there is at least one item here, no 'open' will be emitted...
 		let item = new PopupMenu.PopupMenuItem('Connecting...');
@@ -49,9 +48,9 @@ const AudioOutputSubMenu = GObject.registerClass({
 			if (sink === defsink)
 				continue;
 			item = new PopupMenu.PopupMenuItem(sink.get_description());
-			item.connect('activate', Lang.bind(sink, function() {
-				control.set_default_sink(this);
-			}));
+			item.connect('activate', () => {
+				control.set_default_sink(sink);
+			});
 			this.menu.addMenuItem(item);
 		}
 		if (sinklist.length == 0 ||
@@ -76,16 +75,16 @@ const AudioInputSubMenu = GObject.registerClass({
 		this._control = Main.panel.statusArea.aggregateMenu._volume._control;
 
 
-		this._controlSignal = this._control.connect('default-source-changed', Lang.bind(this, function() {
+		this._controlSignal = this._control.connect('default-source-changed', () => {
 			this._updateDefaultSource();
-		}));
+		});
 
 		this._updateDefaultSource();
 
-		this.menu.connect('open-state-changed', Lang.bind(this, function(menu, isOpen) {
+		this.menu.connect('open-state-changed', (menu, isOpen) => {
 			if (isOpen)
 				this._updateSourceList();
-		}));
+		});
 
 		//Unless there is at least one item here, no 'open' will be emitted...
 		let item = new PopupMenu.PopupMenuItem('Connecting...');
@@ -115,9 +114,9 @@ const AudioInputSubMenu = GObject.registerClass({
 				continue;
 			}
 			item = new PopupMenu.PopupMenuItem(source.get_description());
-			item.connect('activate', Lang.bind(source, function() {
-				control.set_default_source(this);
-			}));
+			item.connect('activate', () => {
+				control.set_default_source(source);
+			});
 			this.menu.addMenuItem(item);
 		}
 		if (sourcelist.length == 0 ||

--- a/extension.js
+++ b/extension.js
@@ -1,10 +1,13 @@
 const Lang = imports.lang;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
+const GObject = imports.gi.GObject;
 
-class AudioOutputSubMenu extends PopupMenu.PopupSubMenuMenuItem {
-	constructor() {
-		super('Audio Output: Connecting...', true);
+const AudioOutputSubMenu = GObject.registerClass({
+    GTypeName: 'ASAudioOutputSubMenu',
+}, class AudioOutputSubMenu extends PopupMenu.PopupSubMenuMenuItem {
+    _init() {
+		super._init('Audio Output: Connecting...', true);
 
 		this._control = Main.panel.statusArea.aggregateMenu._volume._control;
 
@@ -62,11 +65,13 @@ class AudioOutputSubMenu extends PopupMenu.PopupSubMenuMenuItem {
 		this._control.disconnect(this._controlSignal);
 		super.destroy();
 	}
-}
+});
 
-class AudioInputSubMenu extends PopupMenu.PopupSubMenuMenuItem {
-	constructor() {
-		super('Audio Input: Connecting...', true);
+const AudioInputSubMenu = GObject.registerClass({
+    GTypeName: 'ASAudioInputSubMenu',
+}, class AudioInputSubMenu extends PopupMenu.PopupSubMenuMenuItem {
+    _init() {
+		super._init('Audio Input: Connecting...', true);
 
 		this._control = Main.panel.statusArea.aggregateMenu._volume._control;
 
@@ -126,7 +131,7 @@ class AudioInputSubMenu extends PopupMenu.PopupSubMenuMenuItem {
 		this._control.disconnect(this._controlSignal);
 		super.destroy();
 	}
-}
+});
 
 var audioOutputSubMenu = null;
 var audioInputSubMenu = null;


### PR DESCRIPTION
Fixes #12 

Hi,

I'm running Arch, which already has Gnome 3.34(.1).
Basically, my previous fix for Gnome 3.32 was broken by this update, due to some internal magic sourcery.

```
JS ERROR: Extension audio-switcher@AndresCidoncha: TypeError: this._updateDefaultSource is not a function
```

[This](https://stackoverflow.com/a/57549355) explains the issue pretty good - easy fix via `GObject.registerClass(..)`.

Also while at it, I replaced all remaining usages of the `Lang` module, which seems to be deprecated as a whole apparently.

I only tested this on Gnome 3.34 - I cannot say if it also works with Gnome 3.32, but I suppose it does.