### PR TITLE
fix input url so it points to correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This extension adds two little entries to the status-menu that shows the current
 selected pulse-audio-output and pulse-audio-input devices. Clicking on that will open a submenu with
 all available devices and let's you choose which one to use.
 
-All the credits is for anduchs, this extension is based on his work at [Audio Output Switcher](https://github.com/anduchs/audio-output-switcher) and [Audio Input Switcher](https://github.com/anduchs/audio-output-switcher). I only join them and
+All the credits is for anduchs, this extension is based on his work at [Audio Output Switcher](https://github.com/anduchs/audio-output-switcher) and [Audio Input Switcher](https://github.com/anduchs/audio-input-switcher). I only join them and
 add support for the lastest versions of Gnome-shell.
 
 **Thanks to:**


### PR DESCRIPTION
Both links in the Credits were pointing to the "output" github repo.

Changed the "input" link to point to the "input" github repo.