### PR TITLE
Support for GNOME 40

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
 	"3.28",
 	"3.30",
 	"3.32",
-	"3.34"
+	"3.34",
+	"40"
     ],
     "uuid": "audio-switcher@AndresCidoncha",
     "name": "Audio Switcher",


### PR DESCRIPTION
After this small change, the extension is running fine on GNOME 40.